### PR TITLE
MDM-7611: increase socket timeout to 10 minutes

### DIFF
--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
@@ -77,7 +77,7 @@ public class RequestManager implements Serializable {
      * The connection will time out if the period of inactivity after receiving or sending a data
      * packet exceeds the specified value, in milliseconds.
      */
-    private final static int TIMEOUT_SOCKET = 60000;
+    private final static int TIMEOUT_SOCKET = 600000;
 
     /**
      * The maximum number of times a request is retried in case a time out occurs.


### PR DESCRIPTION
We have experienced issues with the upload of huge files > 200mb
which led to a SocketTimeoutException. Therefore this timeout
was increased
