### PR TITLE
Allow to use the host name instead of api url

### DIFF
--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/ArtifactFileUploader.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/ArtifactFileUploader.java
@@ -323,6 +323,12 @@ public class ArtifactFileUploader implements FileCallable<Boolean> {
         final String filePath = this.publication.getIconPath();
         final List<JsonObject> assets = this.uploadAssets(basePath, filePath, null);
 
+        if (assets == null) {
+            this.log.write(this, "Could not upload app icon.");
+            Builds.setResult(this, Result.UNSTABLE, this.log);
+            return;
+        }
+
         if (assets.size() != 1) {
             this.log.write(this, "More than one unpersisted asset returned by server.");
             Builds.setResult(this, Result.UNSTABLE, this.log);

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactory.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactory.java
@@ -18,7 +18,6 @@ package org.jenkinsci.plugins.relution_publisher.net;
 
 import com.google.gson.JsonObject;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.http.nio.entity.NStringEntity;
 import org.jenkinsci.plugins.relution_publisher.configuration.global.Store;
 import org.jenkinsci.plugins.relution_publisher.constants.ApiObject;
@@ -29,6 +28,7 @@ import org.jenkinsci.plugins.relution_publisher.net.requests.BaseRequest;
 import org.jenkinsci.plugins.relution_publisher.net.requests.EntityRequest;
 import org.jenkinsci.plugins.relution_publisher.net.requests.ZeroCopyFileRequest;
 import org.jenkinsci.plugins.relution_publisher.util.Json;
+import org.jenkinsci.plugins.relution_publisher.util.UrlUtils;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -40,69 +40,59 @@ import java.nio.charset.Charset;
  */
 public final class RequestFactory {
 
-    private static final String HEADER_ACCEPT        = "Accept";
-    private static final String HEADER_AUTHORIZATION = "Authorization";
-    private final static String HEADER_CONTENT_TYPE  = "Content-Type";
+    private static final String  HEADER_ACCEPT        = "Accept";
+    private static final String  HEADER_AUTHORIZATION = "Authorization";
+    private final static String  HEADER_CONTENT_TYPE  = "Content-Type";
 
-    private static final String APPLICATION_JSON = "application/json";
-    private static final String BASIC            = "Basic ";
+    private static final String  APPLICATION_JSON     = "application/json";
+    private static final String  BASIC                = "Basic ";
 
-    private final static Charset CHARSET = Charset.forName("UTF-8");
+    private final static Charset CHARSET              = Charset.forName("UTF-8");
+
+    //
+    // Relution paths
+    //
+    /**
+     * The base API URL.
+     */
+    private final static String  URL_API_V1           = "relution/api/v1";
 
     /**
      * The URL used to request the languages configured on the server.
      */
-    private final static String URL_LANGUAGES = "languages";
+    private final static String  URL_LANGUAGES        = URL_API_V1 + "/languages";
 
     /**
      * The URL used to request or persist application objects.
      */
-    private final static String URL_APPS = "apps";
-
-    /**
-     * The URL used to request or persist application version objects.
-     */
-    private final static String URL_VERSIONS = "versions";
+    private final static String  URL_APPS             = URL_API_V1 + "/apps";
 
     /**
      * The URL used to request or persist asset objects.
      */
-    private final static String URL_FILES = "files";
+    private final static String  URL_FILES            = URL_API_V1 + "/files";
 
     /**
      * The URL used to request the unpersisted application object associated with a previously
      * uploaded asset.
      */
-    private final static String URL_APPS_FROM_FILE = "apps/fromFile";
+    private final static String  URL_APPS_FROM_FILE   = URL_API_V1 + "/apps/fromFile";
+
+    //
+    // Path parts
+    //
+    /**
+     * The path used to request or persist application version objects.
+     */
+    private final static String  VERSIONS             = "versions";
 
     private RequestFactory() {
     }
 
-    public static String sanitizePath(final String path) {
-
-        if (StringUtils.isBlank(path)) {
-            return path;
-        }
-
-        if (path.endsWith("/")) {
-            return path.substring(0, path.length() - 1);
-        }
-        return path;
-    }
-
     private static String getUrl(final Store store, final String... parts) {
-
-        final StringBuilder sb = new StringBuilder();
-        sb.append(sanitizePath(store.getUrl()));
-
-        for (final String part : parts) {
-            if (!part.startsWith("/")) {
-                sb.append("/");
-            }
-            final String path = sanitizePath(part);
-            sb.append(path);
-        }
-        return sb.toString();
+        final String baseUrl = UrlUtils.toBaseUrl(store.getUrl());
+        final String path = UrlUtils.combine(parts);
+        return UrlUtils.combine(baseUrl, path);
     }
 
     private static void addAuthentication(final BaseRequest request, final Store store) {
@@ -217,7 +207,7 @@ public final class RequestFactory {
 
         final EntityRequest request = new EntityRequest(
                 Method.POST,
-                getUrl(store, URL_APPS, appUuid, URL_VERSIONS));
+                getUrl(store, URL_APPS, appUuid, VERSIONS));
 
         final NStringEntity entity = new NStringEntity(version.toString(), CHARSET);
         request.setEntity(entity);
@@ -233,7 +223,7 @@ public final class RequestFactory {
 
         final EntityRequest request = new EntityRequest(
                 Method.DELETE,
-                getUrl(store, URL_APPS, appUuid, URL_VERSIONS, uuid));
+                getUrl(store, URL_APPS, appUuid, VERSIONS, uuid));
 
         addAuthentication(request, store);
         return request;

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
@@ -176,7 +176,10 @@ public class RequestManager implements Serializable {
         try {
             final HttpEntity entity = httpResponse.getEntity();
             payload = EntityUtils.toString(entity, CHARSET);
-            return ApiResponse.fromJson(payload);
+
+            if (!StringUtils.isBlank(payload)) {
+                return ApiResponse.fromJson(payload);
+            }
 
         } catch (final Exception e) {
             e.printStackTrace();

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/util/UrlUtils.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/util/UrlUtils.java
@@ -1,0 +1,90 @@
+
+package org.jenkinsci.plugins.relution_publisher.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+
+public class UrlUtils {
+
+    /**
+     * Returns a value indicating whether the specified URL is an HTTP URL.
+     * @param url The URL to test.
+     * @return {@code true} if the specified URL is an HTTP URL; otherwise, {@code false}.
+     */
+    public static boolean isHttpUrl(final String url) {
+        return StringUtils.startsWithIgnoreCase(url, "http://");
+    }
+
+    /**
+     * Returns a value indicating whether the specified URL is an HTTPS URL.
+     * @param url The URL to test.
+     * @return {@code true} if the specified URL is an HTTPS URL; otherwise, {@code false}.
+     */
+    public static boolean isHttpsUrl(final String url) {
+        return StringUtils.startsWithIgnoreCase(url, "https://");
+    }
+
+    /**
+     * Converts the specified URI to its base form, i.e. "<i>protocol://host</i>".
+     * @param uriString A {@link String} that represents the URI to transform.
+     * @return The specified URI reduced to <i>protocol://host</i>, or {@code null} if the
+     * specified URI could not be parsed.
+     */
+    public static String toBaseUrl(final String uriString) {
+        try {
+            final URL url = new URL(uriString);
+            return url.getProtocol() + "://" + url.getHost();
+        } catch (final MalformedURLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Removes a trailing slash from the specified path.
+     * @param path The path to sanitize.
+     * @return The specified path, with any trailing slash removed.
+     */
+    public static String sanitizePath(final String path) {
+        if (StringUtils.isEmpty(path)) {
+            return path;
+        }
+
+        if (path.endsWith("/")) {
+            return path.substring(0, path.length() - 1);
+        }
+
+        return path;
+    }
+
+    /**
+     * Combines the specified array of strings into a path.
+     * <p>
+     * If any part is the start of an absolute HTTP(S) URL the path will be reset and this part
+     * will be used as the path's new starting point.
+     * <p>
+     * <b>Examples:</b><br>
+     * { "a", "b" } --&gt; "/a/b"<br>
+     * { "http://example.com", "a", "b" } --&gt; "http://example.com/a/b"<br>
+     * { "http://example.com", "a", "http://test.com", "b" } --&gt; "http://test.com/b"
+     * @param parts An array of strings to combine.
+     * @return A path constructed from the combined parts.
+     */
+    public static String combine(final String... parts) {
+        final StringBuilder sb = new StringBuilder();
+
+        for (final String part : parts) {
+            if (isHttpUrl(part) || isHttpsUrl(part)) {
+                sb.setLength(0);
+            } else if (!part.startsWith("/")) {
+                sb.append("/");
+            }
+            final String path = sanitizePath(part);
+            sb.append(path);
+        }
+        return sb.toString();
+    }
+}

--- a/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/config.jelly
+++ b/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/config.jelly
@@ -27,7 +27,7 @@
 		to find them. -->
 	<f:section title="${%Relution Enterprise App Store configuration}">
 		<f:entry
-			title="${%App store API URL}"
+			title="${%App store URL}"
 			field="url">
 			<f:textbox />
 		</f:entry>

--- a/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/help-url.html
+++ b/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/help-url.html
@@ -1,4 +1,9 @@
 <div>
-Enter the API URL for a Relution Enterprise App Store.<br/>
-Example: "http[s]://example.com/relution/api/v1/".
+Enter the URL of a Relution Enterprise App Store.<br/>
+<p/>
+<b>Examples:</b>
+<ul>
+<li>https://example.com</li>
+<li>http://example.com</li>
+</ul>
 </div>

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactoryTest.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactoryTest.java
@@ -1,0 +1,120 @@
+
+package org.jenkinsci.plugins.relution_publisher.net;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.JsonObject;
+
+import org.jenkinsci.plugins.relution_publisher.configuration.global.Store;
+import org.jenkinsci.plugins.relution_publisher.constants.ArchiveMode;
+import org.jenkinsci.plugins.relution_publisher.constants.ReleaseStatus;
+import org.jenkinsci.plugins.relution_publisher.constants.UploadMode;
+import org.jenkinsci.plugins.relution_publisher.net.requests.ApiRequest.Method;
+import org.jenkinsci.plugins.relution_publisher.net.requests.EntityRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class RequestFactoryTest {
+
+    private static final String URL_HOST_NAME       = "https://example.com";
+    private static final String URL_HOST_NAME_SLASH = "https://example.com/";
+
+    private static final String URL_API_URL         = "https://example.com/relution/api/v1";
+    private static final String URL_API_URL_SLASH   = "https://example.com/relution/api/v1/";
+
+    private final Store         store               = new Store(
+            "store-1-uuid",
+            "https://example.com",
+            "test",
+            "test",
+            "test",
+            ReleaseStatus.DEFAULT.key,
+            ArchiveMode.DEFAULT.key,
+            UploadMode.DEFAULT.key,
+            null,
+            0,
+            null,
+            null);
+
+    private final JsonObject    app                 = new JsonObject();
+    private final JsonObject    version             = new JsonObject();
+
+    @Before
+    public void initialize() {
+        this.app.addProperty("uuid", "{app-uuid}");
+
+        this.version.addProperty("uuid", "{version-uuid}");
+        this.version.addProperty("appUuid", "{app-uuid}");
+    }
+
+    @Test
+    public void shouldCreatePersistAppRequestFromHostName() {
+        this.store.setUrl(URL_HOST_NAME);
+        final JsonObject app = new JsonObject();
+        app.addProperty("appUuid", "{app-uuid}");
+
+        final EntityRequest request = RequestFactory.createPersistApplicationRequest(this.store, app);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/relution/api/v1/apps");
+    }
+
+    @Test
+    public void shouldCreatePersistAppRequestFromApiUrl() {
+        this.store.setUrl(URL_API_URL);
+        final JsonObject app = new JsonObject();
+        app.addProperty("uuid", "{app-uuid}");
+
+        final EntityRequest request = RequestFactory.createPersistApplicationRequest(this.store, app);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/relution/api/v1/apps");
+    }
+
+    @Test
+    public void shouldCreatePersistVersionRequestFromHostName() {
+        this.store.setUrl(URL_HOST_NAME);
+
+        final EntityRequest request = RequestFactory.createPersistVersionRequest(this.store, this.app, this.version);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/relution/api/v1/apps/{app-uuid}/versions");
+    }
+
+    @Test
+    public void shouldCreatePersistVersionRequestFromApiUrl() {
+        this.store.setUrl(URL_API_URL);
+
+        final EntityRequest request = RequestFactory.createPersistVersionRequest(this.store, this.app, this.version);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/relution/api/v1/apps/{app-uuid}/versions");
+    }
+
+    @Test
+    public void shouldCreateDeleteVersionRequestFromHostName() {
+        this.store.setUrl(URL_HOST_NAME);
+
+        final EntityRequest request = RequestFactory.createDeleteVersionRequest(this.store, this.version);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.DELETE);
+        assertThat(request.getUri()).isEqualTo("https://example.com/relution/api/v1/apps/{app-uuid}/versions/{version-uuid}");
+    }
+
+    @Test
+    public void shouldCreateDeleteVersionRequestFromApiUrl() {
+        this.store.setUrl(URL_API_URL);
+
+        final EntityRequest request = RequestFactory.createDeleteVersionRequest(this.store, this.version);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.DELETE);
+        assertThat(request.getUri()).isEqualTo("https://example.com/relution/api/v1/apps/{app-uuid}/versions/{version-uuid}");
+    }
+}

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/util/UrlUtilsTest.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/util/UrlUtilsTest.java
@@ -1,0 +1,122 @@
+
+package org.jenkinsci.plugins.relution_publisher.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+
+public class UrlUtilsTest {
+
+    @Test
+    public void testCombineBase() {
+        final String result = UrlUtils.combine("http://example.com", "a", "b");
+
+        assertThat(result).as("Combined Url").isEqualTo("http://example.com/a/b");
+    }
+
+    @Test
+    public void testCombineBaseWithSlash() {
+        final String result = UrlUtils.combine("http://example.com", "/a", "b/");
+
+        assertThat(result).as("Combined Url").isEqualTo("http://example.com/a/b");
+    }
+
+    @Test
+    public void testCombineWrap() {
+        final String result = UrlUtils.combine("http://example.com", "a", "http://test.com", "b");
+
+        assertThat(result).as("Combined Url").isEqualTo("http://test.com/b");
+    }
+
+    @Test
+    public void testCombineWrapWithSlash() {
+        final String result = UrlUtils.combine("http://example.com", "/a", "http://test.com", "b/");
+
+        assertThat(result).as("Combined Url").isEqualTo("http://test.com/b");
+    }
+
+    @Test
+    public void testSanitizeUrl() {
+        final String result = UrlUtils.sanitizePath("http://example.com");
+
+        assertThat(result).as("Sanitized Path").isEqualTo("http://example.com");
+    }
+
+    @Test
+    public void testSanitizeUrlWithSlash() {
+        final String result = UrlUtils.sanitizePath("http://example.com/");
+
+        assertThat(result).as("Sanitized Path").isEqualTo("http://example.com");
+    }
+
+    @Test
+    public void testSanitizePath() {
+        final String result = UrlUtils.sanitizePath("/a/b/c");
+
+        assertThat(result).as("Sanitized Path").isEqualTo("/a/b/c");
+    }
+
+    @Test
+    public void testSanitizePathWithSlash() {
+        final String result = UrlUtils.sanitizePath("/a/b/c/");
+
+        assertThat(result).as("Sanitized Path").isEqualTo("/a/b/c");
+    }
+
+    @Test
+    public void shouldBeHttpUrl() {
+        final boolean result = UrlUtils.isHttpUrl("http://example.com");
+
+        assertThat(result).as("Is HTTP URL").isTrue();
+    }
+
+    @Test
+    public void shouldNotBeHttpUrl() {
+        final boolean result = UrlUtils.isHttpUrl("https://example.com");
+
+        assertThat(result).as("Is HTTP URL").isFalse();
+    }
+
+    @Test
+    public void shouldBeHttpsUrl() {
+        final boolean result = UrlUtils.isHttpsUrl("https://example.com");
+
+        assertThat(result).as("Is HTTPS URL").isTrue();
+    }
+
+    @Test
+    public void shouldNotBeHttpsUrl() {
+        final boolean result = UrlUtils.isHttpsUrl("http://example.com");
+
+        assertThat(result).as("Is HTTPS URL").isFalse();
+    }
+
+    @Test
+    public void testToBaseUrl() {
+        final String result = UrlUtils.toBaseUrl("https://example.com:1234/a/b?c=d&e=f");
+
+        assertThat(result).as("Base Url").isEqualTo("https://example.com");
+    }
+
+    @Test
+    public void shouldReturnBaseUrl() {
+        final String result = UrlUtils.toBaseUrl("https://example.com");
+
+        assertThat(result).as("Base Url").isEqualTo("https://example.com");
+    }
+
+    @Test
+    public void shouldReturnBaseUrlFromSlash() {
+        final String result = UrlUtils.toBaseUrl("https://example.com/");
+
+        assertThat(result).as("Base Url").isEqualTo("https://example.com");
+    }
+
+    @Test
+    public void shouldReturnNullForNonUrl() {
+        final String result = UrlUtils.toBaseUrl("some string");
+
+        assertThat(result).as("Base Url").isNull();
+    }
+}


### PR DESCRIPTION
This removes the requirement for the user to specify the server's API URL. It is now enough to specify the server's URL (e.g. https://example.com).
