### PR TITLE
Remove basic authentication use cookies

### DIFF
--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/ArtifactFileUploader.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/ArtifactFileUploader.java
@@ -77,20 +77,20 @@ public class ArtifactFileUploader implements FileCallable<Boolean> {
      * <a href="http://docs.oracle.com/javase/6/docs/platform/serialization/spec/version.html">
      * Versioning of Serializable Objects</a>.
      */
-    private static final long serialVersionUID = 1L;
+    private static final long    serialVersionUID = 1L;
 
     /**
      * Maximum length of text to upload.
      */
-    private static final int MAX_TEXT_LENGTH = 49152;
+    private static final int     MAX_TEXT_LENGTH  = 49152;
 
-    private Result result;
+    private Result               result;
 
-    private final Publication publication;
-    private final Store       store;
-    private final Log         log;
+    private final Publication    publication;
+    private final Store          store;
+    private final Log            log;
 
-    private Set<String> locales;
+    private Set<String>          locales;
 
     private final RequestManager requestManager;
 
@@ -153,7 +153,7 @@ public class ArtifactFileUploader implements FileCallable<Boolean> {
             Builds.setResult(this, Result.UNSTABLE, this.log);
 
         } finally {
-            this.requestManager.shutdown();
+            this.requestManager.close();
 
         }
 

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/global/Store.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/global/Store.java
@@ -19,7 +19,6 @@ package org.jenkinsci.plugins.relution_publisher.configuration.global;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
@@ -421,15 +420,6 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
             e.printStackTrace();
         }
         return this.mUrl;
-    }
-
-    /**
-     * @return An authorization token that can be used to authenticate with the store.
-     */
-    public String getAuthorizationToken() {
-
-        final String authorization = this.mUsername + ":" + this.mOrganization + ":" + this.mPassword;
-        return Base64.encodeBase64String(authorization.getBytes());
     }
 
     /**

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/global/Store.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/global/Store.java
@@ -20,6 +20,7 @@ import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.http.HttpException;
@@ -63,7 +64,7 @@ import hudson.util.ListBoxModel;
  * a version to this store. The default release status can be overridden on a per Jenkins project
  * basis.
  */
-public class Store extends AbstractDescribableImpl<Store>implements Serializable {
+public class Store extends AbstractDescribableImpl<Store> implements Serializable {
 
     /**
      * The serial version number of this class.
@@ -77,44 +78,44 @@ public class Store extends AbstractDescribableImpl<Store>implements Serializable
      * <a href="http://docs.oracle.com/javase/6/docs/platform/serialization/spec/version.html">
      * Versioning of Serializable Objects</a>.
      */
-    private static final long serialVersionUID = 1L;
+    private static final long     serialVersionUID   = 1L;
 
-    public final static String KEY_ID           = "id";
-    public final static String KEY_URL          = "url";
-    public final static String KEY_ORGANIZATION = "organization";
+    public final static String    KEY_ID             = "id";
+    public final static String    KEY_URL            = "url";
+    public final static String    KEY_ORGANIZATION   = "organization";
 
-    public final static String KEY_USERNAME = "username";
-    public final static String KEY_PASSWORD = "password";
+    public final static String    KEY_USERNAME       = "username";
+    public final static String    KEY_PASSWORD       = "password";
 
-    public final static String KEY_RELEASE_STATUS = "releaseStatus";
-    public final static String KEY_ARCHIVE_MODE   = "archiveMode";
-    public final static String KEY_UPLOAD_MODE    = "uploadMode";
+    public final static String    KEY_RELEASE_STATUS = "releaseStatus";
+    public final static String    KEY_ARCHIVE_MODE   = "archiveMode";
+    public final static String    KEY_UPLOAD_MODE    = "uploadMode";
 
-    public final static String KEY_PROXY_HOST = "proxyHost";
-    public final static String KEY_PROXY_PORT = "proxyPort";
+    public final static String    KEY_PROXY_HOST     = "proxyHost";
+    public final static String    KEY_PROXY_PORT     = "proxyPort";
 
-    public final static String KEY_PROXY_USERNAME = "proxyUsername";
-    public final static String KEY_PROXY_PASSWORD = "proxyPassword";
+    public final static String    KEY_PROXY_USERNAME = "proxyUsername";
+    public final static String    KEY_PROXY_PASSWORD = "proxyPassword";
 
-    private final static String[] URL_SCHEMES = {"http", "https"};
+    private final static String[] URL_SCHEMES        = {"http", "https"};
 
-    private String mId;
-    private String mUrl;
+    private String                mId;
+    private String                mUrl;
 
-    private String mOrganization;
+    private String                mOrganization;
 
-    private String mUsername;
-    private String mPassword;
+    private String                mUsername;
+    private String                mPassword;
 
-    private String mReleaseStatus;
-    private String mArchiveMode;
-    private String mUploadMode;
+    private String                mReleaseStatus;
+    private String                mArchiveMode;
+    private String                mUploadMode;
 
-    private String mProxyHost;
-    private int    mProxyPort;
+    private String                mProxyHost;
+    private int                   mProxyPort;
 
-    private String mProxyUsername;
-    private String mProxyPassword;
+    private String                mProxyUsername;
+    private String                mProxyPassword;
 
     /**
      * Creates a new instance of the {@link Store} class initialized with the values in
@@ -577,7 +578,7 @@ public class Store extends AbstractDescribableImpl<Store>implements Serializable
                 @QueryParameter(Store.KEY_PROXY_PORT) final int proxyPort,
                 @QueryParameter(Store.KEY_PROXY_USERNAME) final String proxyUsername,
                 @QueryParameter(Store.KEY_PROXY_PASSWORD) final String proxyPassword)
-                        throws IOException, ServletException {
+                throws IOException, ServletException {
 
             if (StringUtils.isEmpty(url)) {
                 return FormValidation.warning("Unable to validate, the specified URL is empty.");
@@ -587,11 +588,12 @@ public class Store extends AbstractDescribableImpl<Store>implements Serializable
                 return FormValidation.warning("Host name for proxy set, but invalid port configured.");
             }
 
+            RequestManager requestManager = null;
             try {
                 final Store store = new Store(url, organization, username, password, proxyHost, proxyPort, proxyUsername, proxyPassword);
                 final BaseRequest request = RequestFactory.createAppStoreItemsRequest(store);
 
-                final RequestManager requestManager = new RequestManager();
+                requestManager = new RequestManager();
                 requestManager.setProxy(proxyHost, proxyPort);
                 requestManager.setProxyCredentials(proxyUsername, proxyPassword);
 
@@ -619,6 +621,9 @@ public class Store extends AbstractDescribableImpl<Store>implements Serializable
 
             } catch (final Exception e) {
                 return this.parseError(e);
+
+            } finally {
+                IOUtils.closeQuietly(requestManager);
 
             }
         }

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/global/Store.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/global/Store.java
@@ -82,7 +82,6 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
 
     public final static String    KEY_ID             = "id";
     public final static String    KEY_URL            = "url";
-    public final static String    KEY_ORGANIZATION   = "organization";
 
     public final static String    KEY_USERNAME       = "username";
     public final static String    KEY_PASSWORD       = "password";
@@ -101,8 +100,6 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
 
     private String                mId;
     private String                mUrl;
-
-    private String                mOrganization;
 
     private String                mUsername;
     private String                mPassword;
@@ -163,9 +160,13 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
 
         this.setId(id);
         this.setUrl(url);
-        this.setOrganization(organization);
 
-        this.setUsername(username);
+        if (StringUtils.isNotBlank(organization)) {
+            this.setUsername(organization + "\\" + username);
+        } else {
+            this.setUsername(username);
+        }
+
         this.setPassword(password);
 
         this.setReleaseStatus(releaseStatus);
@@ -181,14 +182,13 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
 
     public Store(
             final String url,
-            final String organization,
             final String username,
             final String password,
             final String proxyHost,
             final int proxyPort,
             final String proxyUsername,
             final String proxyPassword) {
-        this(null, url, organization, username, password, null, null, null, proxyHost, proxyPort, proxyUsername, proxyPassword);
+        this(null, url, null, username, password, null, null, null, proxyHost, proxyPort, proxyUsername, proxyPassword);
     }
 
     /**
@@ -198,7 +198,6 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
     public Store(final JSONObject storeJsonObject) {
         this.setId(storeJsonObject.optString(KEY_ID));
         this.setUrl(storeJsonObject.getString(KEY_URL));
-        this.setOrganization(storeJsonObject.getString(KEY_ORGANIZATION));
 
         this.setUsername(storeJsonObject.getString(KEY_USERNAME));
         this.setPassword(storeJsonObject.getString(KEY_PASSWORD));
@@ -249,21 +248,6 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
      */
     public void setUrl(final String url) {
         this.mUrl = url;
-    }
-
-    /**
-     * @return The organization within the store to use.
-     */
-    public String getOrganization() {
-        return this.mOrganization;
-    }
-
-    /**
-     * Sets the organization within the store to use.
-     * @param organization The organization to use.
-     */
-    public void setOrganization(final String organization) {
-        this.mOrganization = organization;
     }
 
     /**
@@ -431,7 +415,6 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
 
         json.put(KEY_ID, this.getId(this.mId));
         json.put(KEY_URL, this.mUrl);
-        json.put(KEY_ORGANIZATION, this.mOrganization);
 
         json.put(KEY_USERNAME, this.mUsername);
         json.put(KEY_PASSWORD, this.mPassword);
@@ -447,19 +430,6 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
         json.put(KEY_PROXY_PASSWORD, this.mProxyPassword);
 
         return json;
-    }
-
-    /**
-     * @return The unique identifier for the {@link Store}.
-     * @deprecated Use {@link #getId()}
-     */
-    @Deprecated
-    public String getIdentifier() {
-        return String.format(
-                "%s:%s:%s",
-                this.mUsername,
-                this.mOrganization,
-                this.mUrl);
     }
 
     @Override
@@ -493,8 +463,7 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
                 Locale.ENGLISH,
                 "%s - %s@%s",
                 this.getHostName(),
-                this.mUsername,
-                this.mOrganization);
+                this.mUsername);
     }
 
     @Extension
@@ -563,7 +532,6 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
         public FormValidation doTestConnection(
                 @QueryParameter(Store.KEY_URL) final String url,
                 @QueryParameter(Store.KEY_USERNAME) final String username,
-                @QueryParameter(Store.KEY_ORGANIZATION) final String organization,
                 @QueryParameter(Store.KEY_PASSWORD) final String password,
                 @QueryParameter(Store.KEY_PROXY_HOST) final String proxyHost,
                 @QueryParameter(Store.KEY_PROXY_PORT) final int proxyPort,
@@ -581,7 +549,7 @@ public class Store extends AbstractDescribableImpl<Store> implements Serializabl
 
             SessionManager sessionManager = null;
             try {
-                final Store store = new Store(url, organization, username, password, proxyHost, proxyPort, proxyUsername, proxyPassword);
+                final Store store = new Store(url, username, password, proxyHost, proxyPort, proxyUsername, proxyPassword);
                 final BaseRequest request = RequestFactory.createAppStoreItemsRequest(store);
 
                 sessionManager = new SessionManager();

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/global/StoreConfiguration.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/global/StoreConfiguration.java
@@ -106,7 +106,6 @@ public class StoreConfiguration extends GlobalConfiguration {
      * @return The {@link Store} with the specified id, or {@code null} if no such store
      * exists.
      */
-    @SuppressWarnings("deprecation")
     public Store getStore(final String storeId) {
         if (this.stores == null) {
             return null;
@@ -114,8 +113,6 @@ public class StoreConfiguration extends GlobalConfiguration {
 
         for (final Store store : this.stores) {
             if (StringUtils.equals(storeId, store.getId())) {
-                return store;
-            } else if (store.getIdentifier().equals(storeId)) {
                 return store;
             }
         }

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/constants/Headers.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/constants/Headers.java
@@ -1,0 +1,30 @@
+
+package org.jenkinsci.plugins.relution_publisher.constants;
+
+public class Headers {
+
+    /**
+     * The HTTP accept header.
+     */
+    public static final String ACCEPT           = "Accept";
+
+    /**
+     * The HTTP authorization header.
+     */
+    public static final String AUTHORIZATION    = "Authorization";
+
+    /**
+     * The HTTP content type header.
+     */
+    public static final String CONTENT_TYPE     = "Content-Type";
+
+    /**
+     * The Relution version header.
+     */
+    public static final String RELUTION_VERSION = "X-Relution-Version";
+
+    /**
+     * The HTTP cookie header.
+     */
+    public static final String SET_COOKIE       = "Set-Cookie";
+}

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/model/ServerVersion.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/model/ServerVersion.java
@@ -1,0 +1,107 @@
+
+package org.jenkinsci.plugins.relution_publisher.model;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+
+public class ServerVersion implements Comparable<ServerVersion>, Serializable {
+
+    /**
+     * The serial version number of this class.
+     * <p>
+     * This version number is used to determine whether a serialized representation of this class
+     * is compatible with the current implementation of the class.
+     * <p>
+     * <b>Note</b> Maintainers must change this value <b>if and only if</b> the new version of this
+     * class is not compatible with old versions.
+     * @see
+     * <a href="http://docs.oracle.com/javase/6/docs/platform/serialization/spec/version.html">
+     * Versioning of Serializable Objects</a>.
+     */
+    private static final long serialVersionUID = 1L;
+
+    private final String      versionName;
+    private final int[]       version;
+
+    public ServerVersion(final String versionName) {
+        this.versionName = versionName;
+        this.version = this.parse(versionName);
+    }
+
+    private int[] parse(final String versionName) {
+        if (StringUtils.isBlank(versionName)) {
+            return new int[] {Integer.MIN_VALUE};
+
+        }
+
+        final String[] values = versionName.split("\\.");
+        final int[] version = new int[values.length];
+
+        for (int n = 0; n < values.length; n++) {
+            try {
+                final String value = values[n];
+                final int number = Integer.parseInt(value);
+                version[n] = number;
+            } catch (final NumberFormatException e) {
+                version[n] = Integer.MAX_VALUE;
+            }
+        }
+
+        return version;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.versionName);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ServerVersion)) {
+            return false;
+        }
+        final ServerVersion other = (ServerVersion) obj;
+        if (!StringUtils.equals(this.versionName, other.versionName)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int compareTo(final ServerVersion o) {
+        final int length = Math.min(this.version.length, o.version.length);
+
+        for (int n = 0; n < length; n++) {
+            final int lhs = this.version[n];
+            final int rhs = o.version[n];
+
+            if (lhs > rhs) {
+                return 1;
+            } else if (lhs < rhs) {
+                return -1;
+            }
+        }
+
+        if (this.version.length > o.version.length) {
+            return 1;
+        } else if (this.version.length < o.version.length) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return this.versionName;
+    }
+}

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactory.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactory.java
@@ -42,7 +42,6 @@ import java.nio.charset.Charset;
 public final class RequestFactory {
 
     private static final String  APPLICATION_JSON   = "application/json";
-    private static final String  BASIC              = "Basic ";
 
     private final static Charset CHARSET            = Charset.forName("UTF-8");
 
@@ -105,12 +104,6 @@ public final class RequestFactory {
         return UrlUtils.combine(baseUrl, path);
     }
 
-    private static void addAuthentication(final BaseRequest request, final Store store) {
-
-        request.setHeader(Headers.ACCEPT, APPLICATION_JSON);
-        request.setHeader(Headers.AUTHORIZATION, BASIC + store.getAuthorizationToken());
-    }
-
     /**
      * Creates a {@link EntityRequest} that can be used to authenticate the user against the server.
      * @param store The {@link Store} this request should be executed against.
@@ -159,7 +152,6 @@ public final class RequestFactory {
                 Method.GET,
                 getUrl(store, URL_LANGUAGES));
 
-        addAuthentication(request, store);
         return request;
     }
 
@@ -176,7 +168,6 @@ public final class RequestFactory {
                 getUrl(store, URL_APPS));
 
         request.queryFields().add("locale", "de");
-        addAuthentication(request, store);
         return request;
     }
 
@@ -191,7 +182,6 @@ public final class RequestFactory {
                 getUrl(store, URL_FILES),
                 file);
 
-        addAuthentication(request, store);
         return request;
     }
 
@@ -209,7 +199,6 @@ public final class RequestFactory {
                 Method.POST,
                 getUrl(store, URL_APPS_FROM_FILE, uuid));
 
-        addAuthentication(request, store);
         return request;
     }
 
@@ -232,7 +221,6 @@ public final class RequestFactory {
         request.setEntity(entity);
 
         request.setHeader(Headers.CONTENT_TYPE, APPLICATION_JSON);
-        addAuthentication(request, store);
         return request;
     }
 
@@ -259,7 +247,6 @@ public final class RequestFactory {
         request.setEntity(entity);
 
         request.setHeader(Headers.CONTENT_TYPE, APPLICATION_JSON);
-        addAuthentication(request, store);
         return request;
     }
 
@@ -271,7 +258,6 @@ public final class RequestFactory {
                 Method.DELETE,
                 getUrl(store, URL_APPS, appUuid, VERSIONS, uuid));
 
-        addAuthentication(request, store);
         return request;
     }
 }

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactory.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactory.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonObject;
 import org.apache.http.nio.entity.NStringEntity;
 import org.jenkinsci.plugins.relution_publisher.configuration.global.Store;
 import org.jenkinsci.plugins.relution_publisher.constants.ApiObject;
+import org.jenkinsci.plugins.relution_publisher.constants.Headers;
 import org.jenkinsci.plugins.relution_publisher.constants.Version;
 import org.jenkinsci.plugins.relution_publisher.net.requests.ApiRequest;
 import org.jenkinsci.plugins.relution_publisher.net.requests.ApiRequest.Method;
@@ -40,14 +41,10 @@ import java.nio.charset.Charset;
  */
 public final class RequestFactory {
 
-    private static final String  HEADER_ACCEPT        = "Accept";
-    private static final String  HEADER_AUTHORIZATION = "Authorization";
-    private final static String  HEADER_CONTENT_TYPE  = "Content-Type";
+    private static final String  APPLICATION_JSON   = "application/json";
+    private static final String  BASIC              = "Basic ";
 
-    private static final String  APPLICATION_JSON     = "application/json";
-    private static final String  BASIC                = "Basic ";
-
-    private final static Charset CHARSET              = Charset.forName("UTF-8");
+    private final static Charset CHARSET            = Charset.forName("UTF-8");
 
     //
     // Relution core paths
@@ -55,12 +52,12 @@ public final class RequestFactory {
     /**
      * The URL used to authenticate the user and start a session.
      */
-    private static final String  URL_AUTH_LOGIN       = "gofer/security/rest/auth/login";
+    private static final String  URL_AUTH_LOGIN     = "gofer/security/rest/auth/login";
 
     /**
      * The URL used to close an existing session.
      */
-    private static final String  URL_AUTH_LOGOUT      = "gofer/security/rest/auth/logout";
+    private static final String  URL_AUTH_LOGOUT    = "gofer/security/rest/auth/logout";
 
     //
     // Relution paths
@@ -68,28 +65,28 @@ public final class RequestFactory {
     /**
      * The base API URL.
      */
-    private final static String  URL_API_V1           = "relution/api/v1";
+    private final static String  URL_API_V1         = "relution/api/v1";
 
     /**
      * The URL used to request the languages configured on the server.
      */
-    private final static String  URL_LANGUAGES        = URL_API_V1 + "/languages";
+    private final static String  URL_LANGUAGES      = URL_API_V1 + "/languages";
 
     /**
      * The URL used to request or persist application objects.
      */
-    private final static String  URL_APPS             = URL_API_V1 + "/apps";
+    private final static String  URL_APPS           = URL_API_V1 + "/apps";
 
     /**
      * The URL used to request or persist asset objects.
      */
-    private final static String  URL_FILES            = URL_API_V1 + "/files";
+    private final static String  URL_FILES          = URL_API_V1 + "/files";
 
     /**
      * The URL used to request the unpersisted application object associated with a previously
      * uploaded asset.
      */
-    private final static String  URL_APPS_FROM_FILE   = URL_API_V1 + "/apps/fromFile";
+    private final static String  URL_APPS_FROM_FILE = URL_API_V1 + "/apps/fromFile";
 
     //
     // Path parts
@@ -97,7 +94,7 @@ public final class RequestFactory {
     /**
      * The path used to request or persist application version objects.
      */
-    private final static String  VERSIONS             = "versions";
+    private final static String  VERSIONS           = "versions";
 
     private RequestFactory() {
     }
@@ -110,8 +107,8 @@ public final class RequestFactory {
 
     private static void addAuthentication(final BaseRequest request, final Store store) {
 
-        request.setHeader(HEADER_ACCEPT, APPLICATION_JSON);
-        request.setHeader(HEADER_AUTHORIZATION, BASIC + store.getAuthorizationToken());
+        request.setHeader(Headers.ACCEPT, APPLICATION_JSON);
+        request.setHeader(Headers.AUTHORIZATION, BASIC + store.getAuthorizationToken());
     }
 
     /**
@@ -131,7 +128,7 @@ public final class RequestFactory {
         final NStringEntity entity = new NStringEntity(credentials.toString(), CHARSET);
         request.setEntity(entity);
 
-        request.setHeader(HEADER_CONTENT_TYPE, APPLICATION_JSON);
+        request.setHeader(Headers.CONTENT_TYPE, APPLICATION_JSON);
         return request;
     }
 
@@ -234,7 +231,7 @@ public final class RequestFactory {
         final NStringEntity entity = new NStringEntity(app.toString(), CHARSET);
         request.setEntity(entity);
 
-        request.setHeader(HEADER_CONTENT_TYPE, APPLICATION_JSON);
+        request.setHeader(Headers.CONTENT_TYPE, APPLICATION_JSON);
         addAuthentication(request, store);
         return request;
     }
@@ -261,7 +258,7 @@ public final class RequestFactory {
         final NStringEntity entity = new NStringEntity(version.toString(), CHARSET);
         request.setEntity(entity);
 
-        request.setHeader(HEADER_CONTENT_TYPE, APPLICATION_JSON);
+        request.setHeader(Headers.CONTENT_TYPE, APPLICATION_JSON);
         addAuthentication(request, store);
         return request;
     }

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactory.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactory.java
@@ -50,6 +50,19 @@ public final class RequestFactory {
     private final static Charset CHARSET              = Charset.forName("UTF-8");
 
     //
+    // Relution core paths
+    //
+    /**
+     * The URL used to authenticate the user and start a session.
+     */
+    private static final String  URL_AUTH_LOGIN       = "gofer/security/rest/auth/login";
+
+    /**
+     * The URL used to close an existing session.
+     */
+    private static final String  URL_AUTH_LOGOUT      = "gofer/security/rest/auth/logout";
+
+    //
     // Relution paths
     //
     /**
@@ -99,6 +112,42 @@ public final class RequestFactory {
 
         request.setHeader(HEADER_ACCEPT, APPLICATION_JSON);
         request.setHeader(HEADER_AUTHORIZATION, BASIC + store.getAuthorizationToken());
+    }
+
+    /**
+     * Creates a {@link EntityRequest} that can be used to authenticate the user against the server.
+     * @param store The {@link Store} this request should be executed against.
+     * @return A request that can be used to authenticate the user.
+     */
+    public static EntityRequest createLoginRequest(final Store store) {
+        final EntityRequest request = new EntityRequest(
+                Method.POST,
+                getUrl(store, URL_AUTH_LOGIN));
+
+        final JsonObject credentials = new JsonObject();
+        credentials.addProperty("userName", store.getUsername());
+        credentials.addProperty("password", store.getPassword());
+
+        final NStringEntity entity = new NStringEntity(credentials.toString(), CHARSET);
+        request.setEntity(entity);
+
+        request.setHeader(HEADER_CONTENT_TYPE, APPLICATION_JSON);
+        return request;
+    }
+
+    /**
+     * Creates a {@link EntityRequest} that can be used to close a session started with a login
+     * request.
+     * @param store The {@link Store} this request should be executed against.
+     * @return A request that can be used to close a session.
+     * @see #createLoginRequest(Store)
+     */
+    public static EntityRequest createLogoutRequest(final Store store) {
+        final EntityRequest request = new EntityRequest(
+                Method.POST,
+                getUrl(store, URL_AUTH_LOGOUT));
+
+        return request;
     }
 
     /**

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
@@ -231,14 +231,6 @@ public class RequestManager implements Closeable, Serializable {
         }
     }
 
-    public HttpHost getProxy() {
-        return this.mProxyHost;
-    }
-
-    public boolean hasCredentials() {
-        return this.mCredentials != null;
-    }
-
     public ApiResponse execute(final ApiRequest request, final Log log) throws IOException, InterruptedException, ExecutionException {
         final HttpResponse httpResponse = this.send(request, log);
         return this.parseNetworkResponse(request, httpResponse);

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
@@ -36,6 +36,7 @@ import org.jenkinsci.plugins.relution_publisher.net.requests.ApiRequest;
 import org.jenkinsci.plugins.relution_publisher.net.responses.ApiResponse;
 import org.jenkinsci.plugins.relution_publisher.util.ErrorType;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.SocketException;
@@ -45,7 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 
-public class RequestManager implements Serializable {
+public class RequestManager implements Closeable, Serializable {
 
     /**
      * The serial version number of this class.
@@ -59,37 +60,37 @@ public class RequestManager implements Serializable {
      * <a href="http://docs.oracle.com/javase/6/docs/platform/serialization/spec/version.html">
      * Versioning of Serializable Objects</a>.
      */
-    private static final long serialVersionUID = 1L;
+    private static final long                  serialVersionUID           = 1L;
 
     /**
      * The maximum amount of time, in milliseconds, to wait for the connection manager to return
      * a connection from the connection pool.
      */
-    private final static int TIMEOUT_CONNECTION_REQUEST = 10000;
+    private final static int                   TIMEOUT_CONNECTION_REQUEST = 10000;
 
     /**
      * The connection attempt will time out if a connection cannot be established within the
      * specified amount of time, in milliseconds.
      */
-    private final static int TIMEOUT_CONNECT = 60000;
+    private final static int                   TIMEOUT_CONNECT            = 60000;
 
     /**
      * The connection will time out if the period of inactivity after receiving or sending a data
      * packet exceeds the specified value, in milliseconds.
      */
-    private final static int TIMEOUT_SOCKET = 600000;
+    private final static int                   TIMEOUT_SOCKET             = 600000;
 
     /**
      * The maximum number of times a request is retried in case a time out occurs.
      */
-    private final static int MAX_REQUEST_RETRIES = 3;
+    private final static int                   MAX_REQUEST_RETRIES        = 3;
 
-    private final static Charset CHARSET = Charset.forName("UTF-8");
+    private final static Charset               CHARSET                    = Charset.forName("UTF-8");
 
     private transient CloseableHttpAsyncClient mHttpClient;
 
-    private HttpHost    mProxyHost;
-    private Credentials mCredentials;
+    private HttpHost                           mProxyHost;
+    private Credentials                        mCredentials;
 
     private CloseableHttpAsyncClient createHttpClient() {
 
@@ -200,9 +201,9 @@ public class RequestManager implements Serializable {
         return response;
     }
 
-    private void silentShutdown() {
+    private void closeQuietly() {
         try {
-            this.shutdown();
+            this.close();
         } catch (final IOException e) {
             // Do nothing
         }
@@ -218,14 +219,14 @@ public class RequestManager implements Serializable {
 
     public void setProxy(final String hostname, final int port) {
         if (!StringUtils.isBlank(hostname) && port != 0) {
-            this.silentShutdown();
+            this.closeQuietly();
             this.mProxyHost = new HttpHost(hostname, port);
         }
     }
 
     public void setProxyCredentials(final String username, final String password) {
         if (!StringUtils.isBlank(username)) {
-            this.silentShutdown();
+            this.closeQuietly();
             this.mCredentials = new UsernamePasswordCredentials(username, password);
         }
     }
@@ -247,7 +248,8 @@ public class RequestManager implements Serializable {
         return this.execute(request, null);
     }
 
-    public void shutdown() throws IOException {
+    @Override
+    public void close() throws IOException {
         if (this.mHttpClient != null) {
             this.mHttpClient.close();
             this.mHttpClient = null;

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
@@ -183,7 +183,7 @@ public class RequestManager implements Closeable, Serializable {
             }
 
         } catch (final Exception e) {
-            e.printStackTrace();
+            System.out.format("Unable to parse server's response: %s\n", e.getMessage());
         }
         final ApiResponse response = new ApiResponse();
         response.setMessage(payload);

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/RequestManager.java
@@ -196,7 +196,7 @@ public class RequestManager implements Serializable {
      */
     private ApiResponse parseNetworkResponse(final ApiRequest request, final HttpResponse httpResponse) {
         final ApiResponse response = this.getJsonString(request, httpResponse);
-        response.init(httpResponse);
+        response.setHttpResponse(httpResponse);
         return response;
     }
 

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/SessionManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/SessionManager.java
@@ -59,14 +59,24 @@ public class SessionManager extends RequestManager {
         final HttpResponse httpResponse = response.getHttpResponse();
 
         final Header cookie = httpResponse.getFirstHeader(Headers.SET_COOKIE);
+
+        if (cookie == null) {
+            return null;
+        }
+
         return this.parseSessionId(cookie.getValue());
     }
 
     private ServerVersion parseServerVersion(final ApiResponse response) {
         final HttpResponse httpResponse = response.getHttpResponse();
 
-        final Header cookie = httpResponse.getFirstHeader(Headers.RELUTION_VERSION);
-        return new ServerVersion(cookie.getValue());
+        final Header version = httpResponse.getFirstHeader(Headers.RELUTION_VERSION);
+
+        if (version == null) {
+            return new ServerVersion(null);
+        }
+
+        return new ServerVersion(version.getValue());
     }
 
     public void logIn(final Store store) throws InterruptedException, ExecutionException, IOException {

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/SessionManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/SessionManager.java
@@ -1,0 +1,117 @@
+
+package org.jenkinsci.plugins.relution_publisher.net;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.jenkinsci.plugins.relution_publisher.configuration.global.Store;
+import org.jenkinsci.plugins.relution_publisher.constants.Headers;
+import org.jenkinsci.plugins.relution_publisher.model.ServerVersion;
+import org.jenkinsci.plugins.relution_publisher.net.requests.ApiRequest;
+import org.jenkinsci.plugins.relution_publisher.net.responses.ApiResponse;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class SessionManager extends RequestManager {
+
+    /**
+     * The serial version number of this class.
+     * <p>
+     * This version number is used to determine whether a serialized representation of this class
+     * is compatible with the current implementation of the class.
+     * <p>
+     * <b>Note</b> Maintainers must change this value <b>if and only if</b> the new version of this
+     * class is not compatible with old versions.
+     * @see
+     * <a href="http://docs.oracle.com/javase/6/docs/platform/serialization/spec/version.html">
+     * Versioning of Serializable Objects</a>.
+     */
+    private static final long serialVersionUID = 1L;
+
+    private Store             store;
+
+    private String            sessionId;
+    private ServerVersion     serverVersion;
+
+    public SessionManager() {
+    }
+
+    private String parseSessionId(final String cookie) {
+        if (StringUtils.isBlank(cookie)) {
+            return null;
+        }
+
+        final Pattern pattern = Pattern.compile("^JSESSIONID=([^;]*);.*$");
+        final Matcher matcher = pattern.matcher(cookie);
+
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+
+        return null;
+    }
+
+    private String parseSessionId(final ApiResponse response) {
+        final HttpResponse httpResponse = response.getHttpResponse();
+
+        final Header cookie = httpResponse.getFirstHeader(Headers.SET_COOKIE);
+        return this.parseSessionId(cookie.getValue());
+    }
+
+    private ServerVersion parseServerVersion(final ApiResponse response) {
+        final HttpResponse httpResponse = response.getHttpResponse();
+
+        final Header cookie = httpResponse.getFirstHeader(Headers.RELUTION_VERSION);
+        return new ServerVersion(cookie.getValue());
+    }
+
+    public void logIn(final Store store) throws InterruptedException, ExecutionException, IOException {
+        if (store == null) {
+            throw new IllegalArgumentException("The specified argument cannot be null: store");
+        }
+
+        if (this.store != null) {
+            throw new IllegalStateException("Already logged in");
+        }
+
+        final ApiRequest request = RequestFactory.createLoginRequest(store);
+        final ApiResponse response = this.execute(request);
+
+        this.store = store;
+        this.sessionId = this.parseSessionId(response);
+        this.serverVersion = this.parseServerVersion(response);
+    }
+
+    public boolean logOut() {
+        if (this.store == null || this.sessionId == null) {
+            return false;
+        }
+
+        try {
+            final ApiRequest request = RequestFactory.createLogoutRequest(this.store);
+            this.execute(request);
+            return true;
+        } catch (final InterruptedException e) {
+            e.printStackTrace();
+            return false;
+        } catch (final ExecutionException e) {
+            e.printStackTrace();
+            return false;
+        } catch (final IOException e) {
+            e.printStackTrace();
+            return false;
+        } finally {
+            this.serverVersion = null;
+            this.sessionId = null;
+            this.store = null;
+        }
+    }
+
+    public ServerVersion getServerVersion() {
+        return this.serverVersion;
+    }
+}

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/SessionManager.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/SessionManager.java
@@ -114,4 +114,10 @@ public class SessionManager extends RequestManager {
     public ServerVersion getServerVersion() {
         return this.serverVersion;
     }
+
+    @Override
+    public void close() throws IOException {
+        this.logOut();
+        super.close();
+    }
 }

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/responses/ApiResponse.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/responses/ApiResponse.java
@@ -34,8 +34,9 @@ public class ApiResponse {
 
     private final static Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
-    private int    statusCode;
-    private String reason;
+    private HttpResponse      httpResponse;
+    private int               statusCode;
+    private String            reason;
 
     private final Integer status;
     private String        message;
@@ -79,13 +80,20 @@ public class ApiResponse {
 
         this.total = object.get("total").getAsInt();
         this.results = object.get("results").getAsJsonArray();
+    /**
+     * Returns the underlying HTTP response.
+     * @return The {@link HttpResponse} from which this API response was parsed.
+     */
+    public HttpResponse getHttpResponse() {
+        return this.httpResponse;
     }
 
     /**
      * Initializes the response from the specified {@link HttpResponse}.
      * @param httpResponse A {@link HttpResponse} used to initialize internal fields.
      */
-    public void init(final HttpResponse httpResponse) {
+    public void setHttpResponse(final HttpResponse httpResponse) {
+        this.httpResponse = httpResponse;
         this.statusCode = httpResponse.getStatusLine().getStatusCode();
         this.reason = httpResponse.getStatusLine().getReasonPhrase();
     }

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/responses/ApiResponse.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/net/responses/ApiResponse.java
@@ -19,9 +19,9 @@ package org.jenkinsci.plugins.relution_publisher.net.responses;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
@@ -38,15 +38,27 @@ public class ApiResponse {
     private int               statusCode;
     private String            reason;
 
-    private final Integer status;
-    private String        message;
+    @Expose
+    @SerializedName("status")
+    private final Integer     status;
 
-    private final JsonObject errors;
+    @Expose
+    @SerializedName("message")
+    private String            message;
 
-    private final int       total;
-    private final JsonArray results;
+    @Expose
+    @SerializedName("errors")
+    private final JsonObject  errors;
 
-    private transient String s;
+    @Expose
+    @SerializedName("total")
+    private final int         total;
+
+    @Expose
+    @SerializedName("results")
+    private final JsonArray   results;
+
+    private transient String  s;
 
     /**
      * Converts the specified JSON formatted string to an instance of the specified class.
@@ -54,9 +66,11 @@ public class ApiResponse {
      * @return An instance of the specified class.
      */
     public static ApiResponse fromJson(final String json) {
-        final JsonParser parser = new JsonParser();
-        final JsonElement element = parser.parse(json);
-        return new ApiResponse(element.getAsJsonObject());
+        final Gson gson = new GsonBuilder()
+                .excludeFieldsWithoutExposeAnnotation()
+                .create();
+
+        return gson.fromJson(json, ApiResponse.class);
     }
 
     /**
@@ -72,14 +86,6 @@ public class ApiResponse {
         this.results = new JsonArray();
     }
 
-    private ApiResponse(final JsonObject object) {
-        this.status = object.get("status").getAsInt();
-
-        this.message = object.get("message").getAsString();
-        this.errors = object.get("errors").getAsJsonObject();
-
-        this.total = object.get("total").getAsInt();
-        this.results = object.get("results").getAsJsonArray();
     /**
      * Returns the underlying HTTP response.
      * @return The {@link HttpResponse} from which this API response was parsed.

--- a/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/config.jelly
+++ b/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/config.jelly
@@ -32,13 +32,8 @@
 			<f:textbox />
 		</f:entry>
 		<f:entry
-			title="${%User name}"
+			title="${%Username}"
 			field="username">
-			<f:textbox />
-		</f:entry>
-		<f:entry
-			title="${%Organization}"
-			field="organization">
 			<f:textbox />
 		</f:entry>
 		<f:entry

--- a/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/help-organization.html
+++ b/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/help-organization.html
@@ -1,5 +1,0 @@
-<div>
-Enter the organization of the account the plugin should use to authenticate itself when connecting
-to the Relution Enterprise App Store. This account must have the necessary permissions to upload
-applications to the store.
-</div>

--- a/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/help-username.html
+++ b/relution-publisher/src/main/resources/org/jenkinsci/plugins/relution_publisher/configuration/global/Store/help-username.html
@@ -1,5 +1,8 @@
 <div>
-Enter the user name of the account the plugin should use to authenticate itself when connecting to
+Enter the username of the account the plugin should use to authenticate itself when connecting to
 the Relution Enterprise App Store. This account must have the necessary permissions to upload
 applications to the store.
+<p/>
+If you have multiple organizations and you have created the same user on several of these
+organizations you may need to specify "organization\username" as the username for disambiguation.
 </div>

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/model/ServerVersionTest.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/model/ServerVersionTest.java
@@ -1,0 +1,128 @@
+
+package org.jenkinsci.plugins.relution_publisher.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+
+public class ServerVersionTest {
+
+    @Test
+    public void majorShouldBeEqual() {
+        final ServerVersion lhs = new ServerVersion("1.0");
+        final ServerVersion rhs = new ServerVersion("1.0");
+
+        assertThat(lhs).isEqualTo(rhs);
+    }
+
+    @Test
+    public void majorShouldNotBeEqual() {
+        final ServerVersion lhs = new ServerVersion("1.0");
+        final ServerVersion rhs = new ServerVersion("2.0");
+
+        assertThat(lhs).isNotEqualTo(rhs);
+    }
+
+    @Test
+    public void majorShouldBeLess() {
+        final ServerVersion lhs = new ServerVersion("1.0");
+        final ServerVersion rhs = new ServerVersion("2.0");
+
+        assertThat(lhs).isLessThan(rhs);
+    }
+
+    @Test
+    public void majorShouldBeGreater() {
+        final ServerVersion lhs = new ServerVersion("2.0");
+        final ServerVersion rhs = new ServerVersion("1.0");
+
+        assertThat(lhs).isGreaterThan(rhs);
+    }
+
+    @Test
+    public void majorShouldBeSame() {
+        final ServerVersion lhs = new ServerVersion("2.0");
+        final ServerVersion rhs = new ServerVersion("2.0");
+
+        assertThat(lhs).isGreaterThanOrEqualTo(rhs);
+        assertThat(rhs).isLessThanOrEqualTo(rhs);
+    }
+
+    @Test
+    public void minorShouldBeEqual() {
+        final ServerVersion lhs = new ServerVersion("1.1");
+        final ServerVersion rhs = new ServerVersion("1.1");
+
+        assertThat(lhs).isEqualTo(rhs);
+    }
+
+    @Test
+    public void minorShouldNotBeEqual() {
+        final ServerVersion lhs = new ServerVersion("1.0");
+        final ServerVersion rhs = new ServerVersion("1.1");
+
+        assertThat(lhs).isNotEqualTo(rhs);
+    }
+
+    @Test
+    public void minorShouldBeLess() {
+        final ServerVersion lhs = new ServerVersion("1.0");
+        final ServerVersion rhs = new ServerVersion("1.1");
+
+        assertThat(lhs).isLessThan(rhs);
+    }
+
+    @Test
+    public void minorShouldBeGreater() {
+        final ServerVersion lhs = new ServerVersion("1.1");
+        final ServerVersion rhs = new ServerVersion("1.0");
+
+        assertThat(lhs).isGreaterThan(rhs);
+    }
+
+    @Test
+    public void minorShouldBeSame() {
+        final ServerVersion lhs = new ServerVersion("1.1");
+        final ServerVersion rhs = new ServerVersion("1.1");
+
+        assertThat(lhs).isGreaterThanOrEqualTo(rhs);
+        assertThat(rhs).isLessThanOrEqualTo(rhs);
+    }
+
+    @Test
+    public void v2_7_4_shouldBeLessThan_v3_36() {
+        final ServerVersion lhs = new ServerVersion("2.7.4");
+        final ServerVersion rhs = new ServerVersion("3.36");
+
+        assertThat(lhs).isNotEqualTo(rhs);
+        assertThat(lhs).isLessThan(rhs);
+        assertThat(rhs).isGreaterThan(lhs);
+    }
+
+    @Test
+    public void v3_40_shouldBeGreaterThan_v3_36() {
+        final ServerVersion lhs = new ServerVersion("3.40");
+        final ServerVersion rhs = new ServerVersion("3.36");
+
+        assertThat(lhs).isNotEqualTo(rhs);
+        assertThat(lhs).isGreaterThan(rhs);
+        assertThat(rhs).isLessThan(lhs);
+    }
+
+    @Test
+    public void nullShouldBeLess() {
+        final ServerVersion lhs = new ServerVersion(null);
+        final ServerVersion rhs = new ServerVersion("1.0");
+
+        assertThat(lhs).isLessThan(rhs);
+    }
+
+    @Test
+    public void unknownShouldBeGreater() {
+        final ServerVersion lhs = new ServerVersion("693091cae45967c27e95b7d4985ef16c24edd65c@origin/master");
+        final ServerVersion rhs = new ServerVersion("1.0");
+
+        assertThat(lhs).isGreaterThan(rhs);
+    }
+}

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactoryTest.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactoryTest.java
@@ -26,9 +26,9 @@ public class RequestFactoryTest {
     private final Store         store               = new Store(
             "store-1-uuid",
             "https://example.com",
-            "test",
-            "test",
-            "test",
+            "organization",
+            "username",
+            "password",
             ReleaseStatus.DEFAULT.key,
             ArchiveMode.DEFAULT.key,
             UploadMode.DEFAULT.key,

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactoryTest.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/net/RequestFactoryTest.java
@@ -49,6 +49,72 @@ public class RequestFactoryTest {
     }
 
     @Test
+    public void shouldCreateLoginRequestFromHostName() {
+        this.store.setUrl(URL_HOST_NAME);
+
+        final EntityRequest request = RequestFactory.createLoginRequest(this.store);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/gofer/security/rest/auth/login");
+    }
+
+    @Test
+    public void shouldCreateLoginRequestFromApiUrl() {
+        this.store.setUrl(URL_API_URL);
+
+        final EntityRequest request = RequestFactory.createLoginRequest(this.store);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/gofer/security/rest/auth/login");
+    }
+
+    @Test
+    public void shouldCreateLoginRequestFromHostNameSlash() {
+        this.store.setUrl(URL_HOST_NAME_SLASH);
+
+        final EntityRequest request = RequestFactory.createLoginRequest(this.store);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/gofer/security/rest/auth/login");
+    }
+
+    @Test
+    public void shouldCreateLoginRequestFromApiUrlSlash() {
+        this.store.setUrl(URL_API_URL_SLASH);
+
+        final EntityRequest request = RequestFactory.createLoginRequest(this.store);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/gofer/security/rest/auth/login");
+    }
+
+    @Test
+    public void shouldCreateLogoutUrlFromHostName() {
+        this.store.setUrl(URL_HOST_NAME);
+
+        final EntityRequest request = RequestFactory.createLogoutRequest(this.store);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/gofer/security/rest/auth/logout");
+    }
+
+    @Test
+    public void shouldCreateLogoutUrlFromApiUrl() {
+        this.store.setUrl(URL_API_URL);
+
+        final EntityRequest request = RequestFactory.createLogoutRequest(this.store);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertThat(request.getUri()).isEqualTo("https://example.com/gofer/security/rest/auth/logout");
+    }
+
+    @Test
     public void shouldCreatePersistAppRequestFromHostName() {
         this.store.setUrl(URL_HOST_NAME);
         final JsonObject app = new JsonObject();


### PR DESCRIPTION
This changes the plugin to remove basic authentication from network requests. The plugin will now log in to the server, perform its action(s) and then log out again.

This also allows to determine the server version before sending requests. This will be used in future updates of the plugin.

The "organization" field has been removed from the settings, it is no longer used/required by default. Users that still need this field can specify the organization as part of the username.
