### PR TITLE
Don't report success on error response

### DIFF
--- a/relution-publisher/.classpath
+++ b/relution-publisher/.classpath
@@ -17,6 +17,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="src/test/resources"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/SingleRequestUploader.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/SingleRequestUploader.java
@@ -68,7 +68,7 @@ public class SingleRequestUploader implements Uploader {
     private void publish(final Artifact artifact, final FileSet fileSet) throws InterruptedException {
         if (fileSet == null) {
             this.log.write(this, "No build artifacts found, upload failed.");
-            Builds.setResult(artifact, Result.UNSTABLE, this.log);
+            Builds.setResult(artifact, Result.NOT_BUILT, this.log);
             return;
         }
 

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/SingleRequestUploader.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/builder/SingleRequestUploader.java
@@ -101,7 +101,9 @@ public class SingleRequestUploader implements Uploader {
         final File app = new File(fileSet.getDirectoryScanner().getBasedir(), fileName);
         final ApiResponse upload = this.upload(artifact, app, changelog);
 
-        this.verifyUpload(upload);
+        if (!this.verifyUpload(upload)) {
+            Builds.setResult(artifact, Result.UNSTABLE, this.log);
+        }
     }
 
     private ApiResponse upload(final Artifact artifact, final File app, final File changelog)

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/jobs/ArtifactPublisher.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/configuration/jobs/ArtifactPublisher.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.relution_publisher.builder.ArtifactFileUploader;
 import org.jenkinsci.plugins.relution_publisher.configuration.global.Store;
 import org.jenkinsci.plugins.relution_publisher.configuration.global.StoreConfiguration;
+import org.jenkinsci.plugins.relution_publisher.logging.BuildLog;
 import org.jenkinsci.plugins.relution_publisher.logging.Log;
 import org.jenkinsci.plugins.relution_publisher.model.UploadMode;
 import org.jenkinsci.plugins.relution_publisher.util.Builds;
@@ -79,7 +80,7 @@ public class ArtifactPublisher extends Recorder {
     @Override
     public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws InterruptedException, IOException {
 
-        final Log log = new Log(listener);
+        final Log log = new BuildLog(listener);
         log.write();
 
         if (this.publications == null) {

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/logging/BuildLog.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/logging/BuildLog.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2013-2015 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jenkinsci.plugins.relution_publisher.logging;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import hudson.model.BuildListener;
+
+
+public class BuildLog implements Log {
+
+    /**
+     * The serial version number of this class.
+     * <p>
+     * This version number is used to determine whether a serialized representation of this class
+     * is compatible with the current implementation of the class.
+     * <p>
+     * <b>Note</b> Maintainers must change this value <b>if and only if</b> the new version of this
+     * class is not compatible with old versions.
+     * @see
+     * <a href="http://docs.oracle.com/javase/6/docs/platform/serialization/spec/version.html">
+     * Versioning of Serializable Objects</a>.
+     */
+    private static final long   serialVersionUID = 1L;
+
+    private final BuildListener listener;
+
+    public BuildLog(final BuildListener listener) {
+        this.listener = listener;
+    }
+
+    private static String valueOf(final Throwable t) {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter(sw);
+
+        t.printStackTrace(pw);
+
+        return sw.toString();
+    }
+
+    @Override
+    public void write() {
+        this.listener.getLogger().println();
+    }
+
+    @Override
+    public void write(final Class<?> source, final String format, final Object... args) {
+        final String message = String.format(
+                "[%s] %s",
+                source.getSimpleName(),
+                String.format(format, args));
+
+        this.listener.getLogger().println(message);
+    }
+
+    @Override
+    public void write(final Object source, final String format, final Object... args) {
+        this.write(source.getClass(), format, args);
+    }
+
+    @Override
+    public void write(final Object source, final String format, final Throwable t) {
+        this.write(source.getClass(), format, valueOf(t));
+    }
+}

--- a/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/logging/Log.java
+++ b/relution-publisher/src/main/java/org/jenkinsci/plugins/relution_publisher/logging/Log.java
@@ -1,77 +1,16 @@
-/*
- * Copyright (c) 2013-2015 M-Way Solutions GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 package org.jenkinsci.plugins.relution_publisher.logging;
 
-import java.io.PrintWriter;
 import java.io.Serializable;
-import java.io.StringWriter;
-
-import hudson.model.BuildListener;
 
 
-public class Log implements Serializable {
+public interface Log extends Serializable {
 
-    /**
-     * The serial version number of this class.
-     * <p>
-     * This version number is used to determine whether a serialized representation of this class
-     * is compatible with the current implementation of the class.
-     * <p>
-     * <b>Note</b> Maintainers must change this value <b>if and only if</b> the new version of this
-     * class is not compatible with old versions.
-     * @see
-     * <a href="http://docs.oracle.com/javase/6/docs/platform/serialization/spec/version.html">
-     * Versioning of Serializable Objects</a>.
-     */
-    private static final long serialVersionUID = 1L;
+    void write();
 
-    private final BuildListener listener;
+    void write(Class<?> source, String format, Object... args);
 
-    public Log(final BuildListener listener) {
-        this.listener = listener;
-    }
+    void write(Object source, String format, Object... args);
 
-    private static String valueOf(final Throwable t) {
-        final StringWriter sw = new StringWriter();
-        final PrintWriter pw = new PrintWriter(sw);
-
-        t.printStackTrace(pw);
-
-        return sw.toString();
-    }
-
-    public void write() {
-        this.listener.getLogger().println();
-    }
-
-    public void write(final Class<?> source, final String format, final Object... args) {
-        final String message = String.format(
-                "[%s] %s",
-                source.getSimpleName(),
-                String.format(format, args));
-
-        this.listener.getLogger().println(message);
-    }
-
-    public void write(final Object source, final String format, final Object... args) {
-        this.write(source.getClass(), format, args);
-    }
-
-    public void write(final Object source, final String format, final Throwable t) {
-        this.write(source.getClass(), format, valueOf(t));
-    }
+    void write(Object source, String format, Throwable t);
 }

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/builder/SingleRequestUploaderTest.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/builder/SingleRequestUploaderTest.java
@@ -1,0 +1,117 @@
+
+package org.jenkinsci.plugins.relution_publisher.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jenkinsci.plugins.relution_publisher.configuration.global.Store;
+import org.jenkinsci.plugins.relution_publisher.configuration.jobs.Publication;
+import org.jenkinsci.plugins.relution_publisher.logging.Log;
+import org.jenkinsci.plugins.relution_publisher.model.ArchiveMode;
+import org.jenkinsci.plugins.relution_publisher.model.Artifact;
+import org.jenkinsci.plugins.relution_publisher.model.ReleaseStatus;
+import org.jenkinsci.plugins.relution_publisher.model.UploadMode;
+import org.jenkinsci.plugins.relution_publisher.net.RequestFactory;
+import org.jenkinsci.plugins.relution_publisher.net.responses.ApiResponse;
+import org.jenkinsci.plugins.relution_publisher.unittest.mocks.MockLog;
+import org.jenkinsci.plugins.relution_publisher.unittest.mocks.MockNetwork;
+import org.jenkinsci.plugins.relution_publisher.unittest.mocks.ResponseBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import hudson.model.Result;
+
+
+public class SingleRequestUploaderTest {
+
+    private final RequestFactory  requestFactory  = new RequestFactory();
+    private final MockNetwork     network         = new MockNetwork();
+    private final Log             log             = new MockLog();
+
+    private final Store           store           = new Store(
+            "store-id",
+            "https://store.example.com",
+            "organization",
+            "username",
+            "password",
+            ReleaseStatus.DEVELOPMENT.key,
+            ArchiveMode.ARCHIVE.key,
+            UploadMode.SUCCESS.key,
+            "proxyHost",
+            8080,
+            "proxyUsername",
+            "proxyPassword");
+
+    private final Publication     publication     = new Publication(
+            "**/build/outputs/apk/example-*.apk",
+            null,
+            "store-id",
+            ReleaseStatus.DEFAULT.key,
+            ArchiveMode.DEFAULT.key,
+            UploadMode.DEFAULT.key,
+            "name",
+            "iconPath",
+            "changelog.txt",
+            "description.txt",
+            "versionName",
+            "environment-uuid");
+
+    private final ResponseBuilder responseBuilder = new ResponseBuilder();
+
+    @Before
+    public void init() throws IOException {
+        final File root = new File("./project/build/outputs/apk");
+        root.mkdirs();
+
+        final File file = new File(root, "example-1.apk");
+        file.createNewFile();
+    }
+
+    @Test
+    public void shouldBeSuccessOnCreateResponse() throws IOException, ExecutionException, InterruptedException {
+        final Uploader uploader = new SingleRequestUploader(this.requestFactory, this.network, this.log);
+        final Artifact artifact = new Artifact(this.store, new File("."), this.publication, Result.SUCCESS);
+        final ApiResponse response = this.responseBuilder.create("post-apps-201.json", 201, "Success");
+        this.network.add(response);
+
+        final Result result = uploader.publish(artifact);
+
+        assertThat(result).isEqualTo(Result.SUCCESS);
+    }
+
+    @Test
+    public void shouldBeUnstableOnAlreadyExistsResponse() throws IOException, ExecutionException, InterruptedException {
+        final Uploader uploader = new SingleRequestUploader(this.requestFactory, this.network, this.log);
+        final Artifact artifact = new Artifact(this.store, new File("."), this.publication, Result.SUCCESS);
+        final ApiResponse response = this.responseBuilder.create("post-apps-422.json", 422, "Success");
+        this.network.add(response);
+
+        final Result result = uploader.publish(artifact);
+
+        assertThat(result).isEqualTo(Result.UNSTABLE);
+    }
+
+    @Test
+    public void shouldBeUnstableOnEmptyResponse() throws IOException, ExecutionException, InterruptedException {
+        final Uploader uploader = new SingleRequestUploader(this.requestFactory, this.network, this.log);
+        final Artifact artifact = new Artifact(this.store, new File("."), this.publication, Result.SUCCESS);
+
+        final Result result = uploader.publish(artifact);
+
+        assertThat(result).isEqualTo(Result.UNSTABLE);
+    }
+
+    @Test
+    public void shouldBeNotBuildIfFileMissing() throws IOException, ExecutionException, InterruptedException {
+        final Uploader uploader = new SingleRequestUploader(this.requestFactory, this.network, this.log);
+        final Artifact artifact = new Artifact(this.store, new File("."), this.publication, Result.SUCCESS);
+        this.publication.setArtifactPath("**/build/outputs/apk/missing-*.apk");
+
+        final Result result = uploader.publish(artifact);
+
+        assertThat(result).isEqualTo(Result.NOT_BUILT);
+    }
+}

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/io/ResourceReader.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/io/ResourceReader.java
@@ -1,0 +1,59 @@
+
+package org.jenkinsci.plugins.relution_publisher.unittest.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+
+public class ResourceReader {
+
+    private static final String RESOURCE_PREFIX = "";
+
+    public String readString(final String resourceName) throws IOException {
+        final String name = RESOURCE_PREFIX + resourceName;
+
+        final ClassLoader classLoader = ResourceReader.class.getClassLoader();
+        final InputStream stream = classLoader.getResourceAsStream(name);
+        assertThat(stream).as("Resource stream").isNotNull();
+
+        final StringBuilder sb = this.read(stream);
+
+        assertThat(sb).as("Resource string").isNotNull();
+        return sb.toString();
+    }
+
+    private StringBuilder read(final InputStream stream) throws IOException {
+
+        if (stream == null) {
+            return null;
+        }
+
+        InputStreamReader reader = null;
+        BufferedReader bufferedReader = null;
+
+        final StringBuilder sb = new StringBuilder();
+
+        try {
+            reader = new InputStreamReader(stream);
+            bufferedReader = new BufferedReader(reader);
+
+            String line;
+
+            while ((line = bufferedReader.readLine()) != null) {
+                sb.append(line);
+            }
+
+        } finally {
+            IOUtils.closeQuietly(bufferedReader);
+            IOUtils.closeQuietly(reader);
+            IOUtils.closeQuietly(stream);
+        }
+        return sb;
+    }
+}

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockHttpResponse.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockHttpResponse.java
@@ -1,0 +1,156 @@
+
+package org.jenkinsci.plugins.relution_publisher.unittest.mocks;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.params.HttpParams;
+
+import java.util.Locale;
+
+
+public class MockHttpResponse implements HttpResponse {
+
+    private StatusLine statusLine;
+
+    public MockHttpResponse() {
+    }
+
+    @Override
+    public ProtocolVersion getProtocolVersion() {
+        if (this.statusLine == null) {
+            return null;
+        }
+        return this.statusLine.getProtocolVersion();
+    }
+
+    @Override
+    public boolean containsHeader(final String name) {
+        return false;
+    }
+
+    @Override
+    public Header[] getHeaders(final String name) {
+        return null;
+    }
+
+    @Override
+    public Header getFirstHeader(final String name) {
+        return null;
+    }
+
+    @Override
+    public Header getLastHeader(final String name) {
+        return null;
+    }
+
+    @Override
+    public Header[] getAllHeaders() {
+        return null;
+    }
+
+    @Override
+    public void addHeader(final Header header) {
+    }
+
+    @Override
+    public void addHeader(final String name, final String value) {
+    }
+
+    @Override
+    public void setHeader(final Header header) {
+    }
+
+    @Override
+    public void setHeader(final String name, final String value) {
+    }
+
+    @Override
+    public void setHeaders(final Header[] headers) {
+    }
+
+    @Override
+    public void removeHeader(final Header header) {
+    }
+
+    @Override
+    public void removeHeaders(final String name) {
+    }
+
+    @Override
+    public HeaderIterator headerIterator() {
+        return null;
+    }
+
+    @Override
+    public HeaderIterator headerIterator(final String name) {
+        return null;
+    }
+
+    @Override
+    public HttpParams getParams() {
+        return null;
+    }
+
+    @Override
+    public void setParams(final HttpParams params) {
+    }
+
+    @Override
+    public StatusLine getStatusLine() {
+        return this.statusLine;
+    }
+
+    @Override
+    public void setStatusLine(final StatusLine statusline) {
+        this.statusLine = statusline;
+    }
+
+    @Override
+    public void setStatusLine(final ProtocolVersion ver, final int code) {
+        this.statusLine = new MockStatusLine(ver, code, null);
+    }
+
+    @Override
+    public void setStatusLine(final ProtocolVersion ver, final int code, final String reason) {
+        this.statusLine = new MockStatusLine(ver, code, reason);
+    }
+
+    @Override
+    public void setStatusCode(final int code) throws IllegalStateException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void setReasonPhrase(final String reason) throws IllegalStateException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public HttpEntity getEntity() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void setEntity(final HttpEntity entity) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public Locale getLocale() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void setLocale(final Locale loc) {
+        // TODO Auto-generated method stub
+
+    }
+}

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockLog.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockLog.java
@@ -22,7 +22,7 @@ public class MockLog implements Log {
 
     @Override
     public void write() {
-        // Do nothing
+        System.out.println();
     }
 
     @Override

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockLog.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockLog.java
@@ -1,0 +1,45 @@
+
+package org.jenkinsci.plugins.relution_publisher.unittest.mocks;
+
+import org.jenkinsci.plugins.relution_publisher.logging.Log;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+
+public class MockLog implements Log {
+
+    private static final long serialVersionUID = 1L;
+
+    private static String valueOf(final Throwable t) {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter(sw);
+
+        t.printStackTrace(pw);
+
+        return sw.toString();
+    }
+
+    @Override
+    public void write() {
+        // Do nothing
+    }
+
+    @Override
+    public void write(final Class<?> source, final String format, final Object... args) {
+        System.out.format(format, args);
+        System.out.println();
+    }
+
+    @Override
+    public void write(final Object source, final String format, final Object... args) {
+        System.out.format(format, args);
+        System.out.println();
+    }
+
+    @Override
+    public void write(final Object source, final String format, final Throwable t) {
+        System.out.format(format, valueOf(t));
+        System.out.println();
+    }
+}

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockNetwork.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockNetwork.java
@@ -1,0 +1,53 @@
+
+package org.jenkinsci.plugins.relution_publisher.unittest.mocks;
+
+import org.jenkinsci.plugins.relution_publisher.logging.Log;
+import org.jenkinsci.plugins.relution_publisher.net.Network;
+import org.jenkinsci.plugins.relution_publisher.net.requests.ApiRequest;
+import org.jenkinsci.plugins.relution_publisher.net.responses.ApiResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+
+public class MockNetwork implements Network {
+
+    private static final long       serialVersionUID = 1L;
+
+    private int                     requestCount;
+    private final List<ApiResponse> responses        = new ArrayList<>();
+
+    public void add(final ApiResponse response) {
+        this.responses.add(response);
+    }
+
+    @Override
+    public void setProxy(final String hostname, final int port) {
+        // Do nothing
+    }
+
+    @Override
+    public void setProxyCredentials(final String username, final String password) {
+        // Do nothing
+    }
+
+    @Override
+    public ApiResponse execute(final ApiRequest request, final Log log) throws IOException, InterruptedException, ExecutionException {
+        if (this.requestCount >= this.responses.size()) {
+            return null;
+        }
+        return this.responses.get(this.requestCount++);
+    }
+
+    @Override
+    public ApiResponse execute(final ApiRequest request) throws InterruptedException, ExecutionException, IOException {
+        return this.execute(request, null);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Do nothing
+    }
+}

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockStatusLine.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/MockStatusLine.java
@@ -1,0 +1,44 @@
+
+package org.jenkinsci.plugins.relution_publisher.unittest.mocks;
+
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+
+
+public class MockStatusLine implements StatusLine {
+
+    private final ProtocolVersion protocolVersion;
+    private final int             httpStatus;
+    private final String          reason;
+
+    public MockStatusLine(final ProtocolVersion protocolVersion, final int httpStatus, final String reason) {
+        this.protocolVersion = protocolVersion;
+        this.httpStatus = httpStatus;
+        this.reason = reason;
+    }
+
+    public MockStatusLine(final int httpStatus, final String reason) {
+        this(null, httpStatus, reason);
+    }
+
+    public MockStatusLine(final StatusLine statusLine, final int httpStatus) {
+        this.protocolVersion = statusLine.getProtocolVersion();
+        this.httpStatus = httpStatus;
+        this.reason = statusLine.getReasonPhrase();
+    }
+
+    @Override
+    public ProtocolVersion getProtocolVersion() {
+        return this.protocolVersion;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String getReasonPhrase() {
+        return this.reason;
+    }
+}

--- a/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/ResponseBuilder.java
+++ b/relution-publisher/src/test/java/org/jenkinsci/plugins/relution_publisher/unittest/mocks/ResponseBuilder.java
@@ -1,0 +1,27 @@
+
+package org.jenkinsci.plugins.relution_publisher.unittest.mocks;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.jenkinsci.plugins.relution_publisher.net.responses.ApiResponse;
+import org.jenkinsci.plugins.relution_publisher.unittest.io.ResourceReader;
+
+import java.io.IOException;
+
+
+public class ResponseBuilder {
+
+    public ApiResponse create(final String resourceName, final int httpStatus, final String reason) throws IOException {
+        final StatusLine statusLine = new MockStatusLine(httpStatus, reason);
+
+        final HttpResponse httpResponse = new MockHttpResponse();
+        httpResponse.setStatusLine(statusLine);
+
+        final ResourceReader reader = new ResourceReader();
+        final String json = reader.readString(resourceName);
+
+        final ApiResponse response = ApiResponse.fromJson(json);
+        response.setHttpResponse(httpResponse);
+        return response;
+    }
+}

--- a/relution-publisher/src/test/resources/post-apps-201.json
+++ b/relution-publisher/src/test/resources/post-apps-201.json
@@ -1,0 +1,148 @@
+{
+    "status": "0",
+    "message": "App created successfully",
+    "errors": {},
+    "exception": null,
+    "total": 1,
+    "results": [
+        {
+            "uuid": "DDD1D28A-B59E-4304-B10E-5EE3D1A9D6AF",
+            "organizationUuid": "07C9A86A-DA15-4CC8-9B6D-A21609C8540E",
+            "type": "NATIVE",
+            "defaultName": "Jenkins Android test",
+            "internalName": "com.mwaysolutions.jenkinsandroidtest",
+            "country": null,
+            "categories": [],
+            "versions": [
+                {
+                    "uuid": "2C0D7FD5-74C5-4F87-A1B9-DB96A3AA8453",
+                    "appUuid": "DDD1D28A-B59E-4304-B10E-5EE3D1A9D6AF",
+                    "releaseStatus": "DEVELOPMENT",
+                    "versionName": "relution-publisher-1.23-3-g302eef8-feature_add-test-android-app",
+                    "versionCode": 1,
+                    "downloadCount": 0,
+                    "link": null,
+                    "screenshots": [],
+                    "icon": {
+                        "uuid": "E58B0750-619A-4A21-906B-D9F8E0E8AE2D",
+                        "name": "ic_launcher.png",
+                        "contentType": "image/png",
+                        "size": 4366,
+                        "modificationDate": 1467968221000,
+                        "downloadCount": 0,
+                        "hashcode": "6pjIPwKEBPETQcDGRmd0Bw==",
+                        "link": "/relution/api/v1/files/E58B0750-619A-4A21-906B-D9F8E0E8AE2D/content",
+                        "properties": {}
+                    },
+                    "platforms": [
+                        "ANDROID"
+                    ],
+                    "keywords": {},
+                    "constraints": [
+                        {
+                            "name": "osversion",
+                            "value": "2.3.3",
+                            "type": "string"
+                        },
+                        {
+                            "name": "osversionnumber",
+                            "value": 2000300030000,
+                            "type": "long"
+                        },
+                        {
+                            "name": "require.sw.api.min",
+                            "value": 10,
+                            "type": "long"
+                        },
+                        {
+                            "name": "require.sw.api.opt",
+                            "value": 24,
+                            "type": "long"
+                        }
+                    ],
+                    "copyright": null,
+                    "developerName": null,
+                    "publisherId": null,
+                    "developerWeb": null,
+                    "developerEmail": null,
+                    "createdBy": "ppp",
+                    "creationDate": 1467968221147,
+                    "modifiedBy": "ppp",
+                    "modificationDate": 1467968221147,
+                    "assigneeUuid": null,
+                    "workflowStep": null,
+                    "expirationDate": null,
+                    "provisioningInfo": {
+                        "applicationIdentifierPrefix": null,
+                        "creationDate": null,
+                        "expirationDate": null,
+                        "entitlements": {},
+                        "name": null,
+                        "teamName": null
+                    },
+                    "features": [],
+                    "changelog": {},
+                    "rating": 0,
+                    "ratingCount": 0,
+                    "description": {},
+                    "installCount": 0,
+                    "file": {
+                        "uuid": "16083F49-8A5A-49B8-9134-32F22558FC4E",
+                        "name": "app-v1.apk",
+                        "contentType": "application/vnd.android.package-archive",
+                        "size": 1263954,
+                        "modificationDate": 1467968221094,
+                        "downloadCount": 0,
+                        "hashcode": "NZQa6wXmmqliTicr9dwWew==",
+                        "link": "/relution/api/v1/files/16083F49-8A5A-49B8-9134-32F22558FC4E/content",
+                        "properties": {}
+                    },
+                    "name": {
+                        "en_US": "Jenkins Android test",
+                        "de_DE": "Jenkins Android test"
+                    },
+                    "hiddenGroups": []
+                }
+            ],
+            "createdBy": "ppp",
+            "creationDate": 1467968221147,
+            "modifiedBy": "ppp",
+            "modificationDate": 1467968221147,
+            "rating": 0,
+            "ratingCount": 0,
+            "downloadCount": 0,
+            "autoUpdate": false,
+            "externalId": null,
+            "priceType": "FREE",
+            "requested": false,
+            "requestCount": 0,
+            "currency": null,
+            "price": 0,
+            "securityRating": null,
+            "securityRatingPending": false,
+            "canUpdateSecurityRating": false,
+            "expirationDate": null,
+            "environment": null,
+            "acl": {
+                "DEVELOPMENT": [
+                    "644E01EC-1235-4CD1-9F4C-1FC56D026E27:r",
+                    "972C0997-20B9-45DA-8233-BBDC13C31CAE:rw"
+                ],
+                "ARCHIVE": [
+                    "972C0997-20B9-45DA-8233-BBDC13C31CAE:rw"
+                ],
+                "REVIEW": [
+                    "0F213DB7-A607-4412-8A1A-E602B62CDD3D:w",
+                    "644E01EC-1235-4CD1-9F4C-1FC56D026E27:rw",
+                    "972C0997-20B9-45DA-8233-BBDC13C31CAE:rw"
+                ],
+                "RELEASE": [
+                    "0F213DB7-A607-4412-8A1A-E602B62CDD3D:r",
+                    "644E01EC-1235-4CD1-9F4C-1FC56D026E27:rw",
+                    "65EA7149-E95D-4810-AA7F-6CFC4FC7A5E5:r",
+                    "972C0997-20B9-45DA-8233-BBDC13C31CAE:rw"
+                ]
+            }
+        }
+    ]
+}

--- a/relution-publisher/src/test/resources/post-apps-422.json
+++ b/relution-publisher/src/test/resources/post-apps-422.json
@@ -1,0 +1,18 @@
+{
+    "status": "-1",
+    "message": "Version already exists. Please delete the old one to upload the same version again.",
+    "errors": {
+        "2047": "Version already exists. Please delete the old one to upload the same version again."
+    },
+    "exception": {
+        "className": "com.mwaysolutions.relution.common.domain.RelutionException",
+        "cause": null,
+        "errorCode": "VERSION_ALREADY_EXISTS",
+        "httpStatus": 422,
+        "message": "Version already exists. Please delete the old one to upload the same version again.",
+        "localizedMessage": "Version already exists. Please delete the old one to upload the same version again.",
+        "suppressed": []
+    },
+    "total": 0,
+    "results": []
+}


### PR DESCRIPTION
This fixes the issue that the new SingleRequestUploader reports success even when the server returns an error response (e.g. version already exists).

This merge request adds unit tests that were used to reproduce the issue and a fix for the issue.
